### PR TITLE
Changed the URL of the sources to include all sub modules

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/matomo-org/matomo/archive/refs/tags/4.3.1.tar.gz
-SOURCE_SUM=1b81dff17dd35e1b3a1fe6a5fe28a2916c5fb5537bf3fafc13020f52becf888a
+SOURCE_URL=https://builds.matomo.org/matomo-4.3.1.tar.gz
+SOURCE_SUM=55ee0fd5c555fee679f4171069464b4d33b0a635fbbdea1ff6347497763dc4e4
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/scripts/install
+++ b/scripts/install
@@ -97,15 +97,6 @@ phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
 #=================================================
 # SPECIFIC SETUP
 #=================================================
-# INSTALL COMPOSER AND DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Installing Composer and dependencies..."
-
-ynh_install_composer
-
-# Install missing icons
-ynh_setup_source --dest_dir="$final_path/plugins/Morpheus/icons" --source_id="icons"
-chmod -R 755 "$final_path/plugins/Morpheus"
 
 #=================================================
 # SETUP A CRON

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -119,28 +119,6 @@ ynh_add_fpm_config --usage=low --footprint=low --package="$extra_php_dependencie
 #=================================================
 # SPECIFIC UPGRADE
 #=================================================
-# INSTALL COMPOSER AND DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Installating composer and dependencies..."
-
-if [ "$upgrade_type" == "UPGRADE_APP" ]
-then
-	ynh_install_composer --phpversion="$phpversion" --workdir="$final_path"
-	if [[ -f "$final_path/config/config.ini.php" ]]; then
-	php$phpversion $final_path/console core:update -n
-	fi
-fi
-
-#=================================================
-# INSTALL MISSING ICONS
-#=================================================
-
-if [ ! "$(ls -A "$final_path/plugins/Morpheus/icons")" ]
-then
-	ynh_script_progression --message="Installating Morpheus icons..."
-    ynh_setup_source --dest_dir="$final_path/plugins/Morpheus/icons" --source_id="icons"
-    chmod -R 755 "$final_path/plugins/Morpheus"
-fi
 
 #=================================================
 # SETUP A CRON


### PR DESCRIPTION
## Problem

After installation, the git sub-modules (e.g. tag manager) are not present

## Solution

Instead of using the link of the GitHub archive, use the official link present in the documentation

I have tried a manual installation on a local instance. No error during installation.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
