### PR TITLE
Fix linter warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Matomo for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/matomo.svg)](https://dash.yunohost.org/appci/app/matomo) ![Working status](https://ci-apps.yunohost.org/ci/badges/matomo.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/matomo.maintain.svg)  
+[![Integration level](https://dash.yunohost.org/integration/matomo.svg)](https://dash.yunohost.org/appci/app/matomo) ![Working status](https://ci-apps.yunohost.org/ci/badges/matomo.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/matomo.maintain.svg)
 [![Install Matomo with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=matomo)
 
 *[Lire ce readme en français.](./README_fr.md)*
@@ -22,7 +22,7 @@ Matomo is a full-featured PHP MySQL software program that you download and insta
 Matomo aims to be a Free software alternative to Google Analytics and is already used on more than 1,400,000 websites. Privacy is built-in!
 
 
-**Shipped version:** 4.13.1~ynh1
+**Shipped version:** 4.13.2~ynh1
 
 **Demo:** https://demo.matomo.org
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Matomo pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/matomo.svg)](https://dash.yunohost.org/appci/app/matomo) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/matomo.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/matomo.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/matomo.svg)](https://dash.yunohost.org/appci/app/matomo) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/matomo.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/matomo.maintain.svg)
 [![Installer Matomo avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=matomo)
 
 *[Read this readme in english.](./README.md)*
@@ -22,7 +22,7 @@ Matomo is a full-featured PHP MySQL software program that you download and insta
 Matomo aims to be a Free software alternative to Google Analytics and is already used on more than 1,400,000 websites. Privacy is built-in!
 
 
-**Version incluse :** 4.13.1~ynh1
+**Version incluse :** 4.13.2~ynh1
 
 **Démo :** https://demo.matomo.org
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://builds.matomo.org/matomo-4.13.1.tar.gz
-SOURCE_SUM=d0439ee9895a86d51698d6ea593b6e45e2f4ea4925ef198f7c7027ab87fc4cf9
+SOURCE_URL=https://builds.matomo.org/matomo-4.13.2.tar.gz
+SOURCE_SUM=f6bead008e2ac370df0e8df4ba643e7b05d733714f2f4d3f7b7928d0ef4ff44a
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/conf/msg_install
+++ b/conf/msg_install
@@ -1,0 +1,12 @@
+__APP__ was successfully installed :)
+
+Please open your __APP__ domain: https://__DOMAIN____PATH_URL__
+
+Complete the registration process from the setup page displayed.
+Details for MySQL database to be enterted while registration process:
+
+Database login:    db_user
+Database name:     db_name
+Database password: db_pwd
+
+If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/matomo_ynh/issues"

--- a/conf/msg_remove
+++ b/conf/msg_remove
@@ -1,0 +1,5 @@
+__APP__ was successfully removed :)
+
+The domain https://__DOMAIN____PATH_URL__ is free for other apps to be installed on it.
+
+If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/matomo_ynh/issues"

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Analytics platform for measuring Web statistics",
         "fr": "Plateforme d'analyse de mesure de statistiques Web"
     },
-    "version": "4.13.1~ynh1",
+    "version": "4.13.2~ynh1",
     "url": "https://matomo.org",
     "upstream": {
         "license": "GPL-3.0-or-later",

--- a/scripts/install
+++ b/scripts/install
@@ -7,6 +7,7 @@
 #=================================================
 
 source _common.sh
+source ynh_send_readme_to_admin__2
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -145,20 +146,7 @@ ynh_systemd_action --service_name=nginx --action=reload
 #=================================================
 ynh_script_progression --message="Sending a readme for the admin..." --weight=1
 
-message="Matomo was successfully installed
-
-Please open your $app domain: https://$domain$path_url
-
-Complete the registration process from the setup page displayed.
-Details for MySQL database to be enterted while registration process:
-
-Database login:    $db_user
-Database name:     $db_name
-Database password: $db_pwd
-
-If you are facing any problem or want to improve this app, please open a new issue here: https://github.com/YunoHost-Apps/matomo_ynh/issues"
-
-ynh_send_readme_to_admin "$message"
+ynh_send_readme_to_admin --app_message="../conf/msg_install" --recipients=$admin_mail --type='install'
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/install
+++ b/scripts/install
@@ -29,6 +29,7 @@ admin=$YNH_APP_ARG_ADMIN
 app=$YNH_APP_INSTANCE_NAME
 
 email=$(ynh_user_get_info --username=$admin --key=mail)
+
 fpm_footprint="low"
 fpm_free_footprint=0
 fpm_usage="low"
@@ -146,7 +147,7 @@ ynh_systemd_action --service_name=nginx --action=reload
 #=================================================
 ynh_script_progression --message="Sending a readme for the admin..." --weight=1
 
-ynh_send_readme_to_admin --app_message="../conf/msg_install" --recipients=$admin_mail --type='install'
+ynh_send_readme_to_admin --app_message="../conf/msg_install" --recipients=$email --type='install'
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -21,6 +21,7 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_user=$db_name
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+path_url=$(ynh_app_setting_get --app=$app --key=path)
 email=$(ynh_user_get_info --username=$admin --key="mail")
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -7,6 +7,7 @@
 #=================================================
 
 source _common.sh
+source ynh_send_readme_to_admin__2
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -82,6 +83,13 @@ ynh_script_progression --message="Removing the dedicated system user..." --weigh
 
 # Delete a system user
 ynh_system_user_delete --username=$app
+
+#=================================================
+# SEND A README FOR THE ADMIN
+#=================================================
+ynh_script_progression --message="Sending a readme for the admin..."
+
+ynh_send_readme_to_admin --app_message="../conf/msg_remove" --recipients=$admin_mail --type='remove'
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/remove
+++ b/scripts/remove
@@ -21,6 +21,7 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_user=$db_name
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+email=$(ynh_user_get_info --username=$admin --key="mail")
 
 #=================================================
 # STANDARD REMOVE
@@ -89,7 +90,7 @@ ynh_system_user_delete --username=$app
 #=================================================
 ynh_script_progression --message="Sending a readme for the admin..."
 
-ynh_send_readme_to_admin --app_message="../conf/msg_remove" --recipients=$admin_mail --type='remove'
+ynh_send_readme_to_admin --app_message="../conf/msg_remove" --recipients=$email --type='remove'
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/ynh_send_readme_to_admin__2
+++ b/scripts/ynh_send_readme_to_admin__2
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Send an email to inform the administrator
+#
+# usage: ynh_send_readme_to_admin --app_message=app_message [--recipients=recipients] [--type=type]
+# | arg: -m --app_message= - The file with the content to send to the administrator.
+# | arg: -r, --recipients= - The recipients of this email. Use spaces to separate multiples recipients. - default: root
+#	example: "root admin@domain"
+#	If you give the name of a YunoHost user, ynh_send_readme_to_admin will find its email adress for you
+#	example: "root admin@domain user1 user2"
+# | arg: -t, --type= - Type of mail, could be 'backup', 'change_url', 'install', 'remove', 'restore', 'upgrade'
+#
+# Requires YunoHost version 4.1.0 or higher.
+ynh_send_readme_to_admin() {
+	# Declare an array to define the options of this helper.
+	declare -Ar args_array=( [m]=app_message= [r]=recipients= [t]=type= )
+	local app_message
+	local recipients
+	local type
+	# Manage arguments with getopts
+
+	ynh_handle_getopts_args "$@"
+	app_message="${app_message:-}"
+	recipients="${recipients:-root}"
+	type="${type:-install}"
+
+	# Get the value of admin_mail_html
+	admin_mail_html=$(ynh_app_setting_get $app admin_mail_html)
+	admin_mail_html="${admin_mail_html:-0}"
+
+	# Retrieve the email of users
+	find_mails () {
+		local list_mails="$1"
+		local mail
+		local recipients=" "
+		# Read each mail in argument
+		for mail in $list_mails
+		do
+			# Keep root or a real email address as it is
+			if [ "$mail" = "root" ] || echo "$mail" | grep --quiet "@"
+			then
+				recipients="$recipients $mail"
+			else
+				# But replace an user name without a domain after by its email
+				if mail=$(ynh_user_get_info "$mail" "mail" 2> /dev/null)
+				then
+					recipients="$recipients $mail"
+				fi
+			fi
+		done
+		echo "$recipients"
+	}
+	recipients=$(find_mails "$recipients")
+
+	# Subject base
+	local mail_subject="☁️🆈🅽🅷☁️: \`$app\`"
+
+	# Adapt the subject according to the type of mail required.
+	if [ "$type" = "backup" ]; then
+		mail_subject="$mail_subject has just been backup."
+	elif [ "$type" = "change_url" ]; then
+		mail_subject="$mail_subject has just been moved to a new URL!"
+	elif [ "$type" = "remove" ]; then
+		mail_subject="$mail_subject has just been removed!"
+	elif [ "$type" = "restore" ]; then
+		mail_subject="$mail_subject has just been restored!"
+	elif [ "$type" = "upgrade" ]; then
+		mail_subject="$mail_subject has just been upgraded!"
+	else	# install
+		mail_subject="$mail_subject has just been installed!"
+	fi
+
+	ynh_add_config --template="$app_message" --destination="../conf/msg__to_send"
+
+	ynh_delete_file_checksum --file="../conf/msg__to_send"
+
+	local mail_message="This is an automated message from your beloved YunoHost server.
+
+Specific information for the application $app.
+
+$(cat "../conf/msg__to_send")"
+
+	# Store the message into a file for further modifications.
+	echo "$mail_message" > mail_to_send
+
+	# If a html email is required. Apply html tags to the message.
+ 	if [ "$admin_mail_html" -eq 1 ]
+ 	then
+		# Insert 'br' tags at each ending of lines.
+		ynh_replace_string "$" "<br>" mail_to_send
+
+		# Insert starting HTML tags
+		sed --in-place '1s@^@<!DOCTYPE html>\n<html>\n<head></head>\n<body>\n@' mail_to_send
+
+		# Keep tabulations
+		ynh_replace_string "  " "\&#160;\&#160;" mail_to_send
+		ynh_replace_string "\t" "\&#160;\&#160;" mail_to_send
+
+		# Insert url links tags
+		ynh_replace_string "__URL_TAG1__\(.*\)__URL_TAG2__\(.*\)__URL_TAG3__" "<a href=\"\2\">\1</a>" mail_to_send
+
+		# Insert finishing HTML tags
+		echo -e "\n</body>\n</html>" >> mail_to_send
+
+	# Otherwise, remove tags to keep a plain text.
+	else
+		# Remove URL tags
+		ynh_replace_string "__URL_TAG[1,3]__" "" mail_to_send
+		ynh_replace_string "__URL_TAG2__" ": " mail_to_send
+	fi
+
+	# Define binary to use for mail command
+	if [ -e /usr/bin/bsd-mailx ]
+	then
+		local mail_bin=/usr/bin/bsd-mailx
+	else
+		local mail_bin=/usr/bin/mail.mailutils
+	fi
+
+	if [ "$admin_mail_html" -eq 1 ]
+	then
+		content_type="text/html"
+	else
+		content_type="text/plain"
+	fi
+
+	# Send the email to the recipients
+	cat mail_to_send | $mail_bin -a "Content-Type: $content_type; charset=UTF-8" -s "$mail_subject" "$recipients"
+}


### PR DESCRIPTION
## Problem

 ! scripts/install

    ! It looks like this app requires the admin to finish the install by entering DB credentials. Unless it's absolutely not easily automatizable, this should be handled automatically by the app install script using curl calls, or (CLI tools provided by the upstream maybe ?). 


## Solution

Add ynh_send_readme_to_admin__2

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
