### PR TITLE
Change url: Update trusted hosts

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -1,6 +1,6 @@
 # All available README files by language
 
 - [Read the README in English](README.md)
+- [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)
-- [Leggi il “README” in italiano](README_it.md)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It shall NOT be edited by hand.
 
 [![Install Matomo with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=matomo)
 
-*[Read this README is other languages.](./ALL_README.md)*
+*[Read this README in other languages.](./ALL_README.md)*
 
 > *This package allows you to install Matomo quickly and simply on a YunoHost server.*  
 > *If you don't have YunoHost, please consult [the guide](https://yunohost.org/install) to learn how to install it.*
@@ -21,7 +21,7 @@ Matomo is the leading Free/Libre open analytics platform. At the end of the five
 Matomo aims to be a Free software alternative to Google Analytics and is already used on more than 1,400,000 websites. Privacy is built-in!
 
 
-**Shipped version:** 5.0.2~ynh1
+**Shipped version:** 5.0.3~ynh1
 
 **Demo:** <https://demo.matomo.org>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -1,0 +1,52 @@
+<!--
+Ohart ongi: README hau automatikoki sortu da <https://github.com/YunoHost/apps/tree/master/tools/readme_generator>ri esker
+EZ editatu eskuz.
+-->
+
+# Matomo YunoHost-erako
+
+[![Integrazio maila](https://dash.yunohost.org/integration/matomo.svg)](https://dash.yunohost.org/appci/app/matomo) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/matomo.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/matomo.maintain.svg)
+
+[![Instalatu Matomo YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=matomo)
+
+*[Irakurri README hau beste hizkuntzatan.](./ALL_README.md)*
+
+> *Pakete honek Matomo YunoHost zerbitzari batean azkar eta zailtasunik gabe instalatzea ahalbidetzen dizu.*  
+> *YunoHost ez baduzu, kontsultatu [gida](https://yunohost.org/install) nola instalatu ikasteko.*
+
+## Aurreikuspena
+
+Matomo is the leading Free/Libre open analytics platform. At the end of the five-minute installation process, you will be given a JavaScript code. Simply copy and paste this tag on websites you wish to track and access your analytics reports in real-time.
+
+Matomo aims to be a Free software alternative to Google Analytics and is already used on more than 1,400,000 websites. Privacy is built-in!
+
+
+**Paketatutako bertsioa:** 5.0.3~ynh1
+
+**Demoa:** <https://demo.matomo.org>
+
+## Pantaila-argazkiak
+
+![Matomo(r)en pantaila-argazkia](./doc/screenshots/screenshot.png)
+
+## Dokumentazioa eta baliabideak
+
+- Aplikazioaren webgune ofiziala: <https://matomo.org>
+- Administratzaileen dokumentazio ofiziala: <https://matomo.org/docs>
+- Jatorrizko aplikazioaren kode-gordailua: <https://github.com/matomo-org/matomo>
+- YunoHost Denda: <https://apps.yunohost.org/app/matomo>
+- Eman errore baten berri: <https://github.com/YunoHost-Apps/matomo_ynh/issues>
+
+## Garatzaileentzako informazioa
+
+Bidali `pull request`a [`testing` abarrera](https://github.com/YunoHost-Apps/matomo_ynh/tree/testing).
+
+`testing` abarra probatzeko, ondorengoa egin:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/matomo_ynh/tree/testing --debug
+edo
+sudo yunohost app upgrade matomo -u https://github.com/YunoHost-Apps/matomo_ynh/tree/testing --debug
+```
+
+**Informazio gehiago aplikazioaren paketatzeari buruz:** <https://yunohost.org/packaging_apps>

--- a/README_fr.md
+++ b/README_fr.md
@@ -20,7 +20,7 @@ Matomo est la principale plateforme d'analyse ouverte Free/Libre. À la fin du p
 
 Matomo se veut une alternative logicielle gratuite à Google Analytics et est déjà utilisé sur plus de 1 400 000 sites Web. La confidentialité est intégrée !
 
-**Version incluse :** 5.0.2~ynh1
+**Version incluse :** 5.0.3~ynh1
 
 **Démo :** <https://demo.matomo.org>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -21,7 +21,7 @@ Matomo is the leading Free/Libre open analytics platform. At the end of the five
 Matomo aims to be a Free software alternative to Google Analytics and is already used on more than 1,400,000 websites. Privacy is built-in!
 
 
-**Versión proporcionada:** 5.0.2~ynh1
+**Versión proporcionada:** 5.0.3~ynh1
 
 **Demo:** <https://demo.matomo.org>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Matomo"
 description.en = "Analytics platform for measuring Web statistics"
 description.fr = "Plateforme d'analyse de mesure de statistiques Web"
 
-version = "5.0.2~ynh1"
+version = "5.0.3~ynh1"
 
 maintainers = []
 
@@ -51,9 +51,10 @@ ram.runtime = "50M"
     [resources.sources]
 
         [resources.sources.main]
-        url = "https://github.com/matomo-org/matomo/releases/download/5.0.2/matomo-5.0.2.tar.gz"
-        sha256 = "acb0128492edcdddc707525ef8ffa2f0629675e925c82dac4e798f474ecc77ef"
+        url = "https://github.com/matomo-org/matomo/releases/download/5.0.3/matomo-5.0.3.tar.gz"
+        sha256 = "cd656ee7df4b29ac453456c6b9708d8264093ac2c99d6669d2830f31624cd626"
         autoupdate.strategy = "latest_github_release"
+        autoupdate.asset = "^matomo-.*tar.gz$"
 
     [resources.system_user]
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -19,6 +19,16 @@ ynh_script_progression --message="Updating NGINX web server configuration..." --
 ynh_change_url_nginx_config
 
 #=================================================
+# SPECIFIC MODIFICATIONS
+#=================================================
+# RECONFIGURING MATOMO
+#=================================================
+ynh_script_progression --message="Reconfiguring Matomo..." --weight=2
+
+# See https://matomo.org/faq/how-to-install/faq_18/
+ynh_replace_string --match_string="trusted_hosts[] = \"$old_domain\"" --replace_string="trusted_hosts[] = \"$new_domain\"" --target_file="$install_dir/config/config.ini.php"
+
+#=================================================
 # SETUP A CRON
 #=================================================
 ynh_script_progression --message="Setuping a cron..." --weight=1


### PR DESCRIPTION
## Problem

Recently, I changed the URL of my Matomo app. Afterwards the new URL hadn't been added to trusted_hosts.

## Solution

So, I just updated `trusted_hosts[]` value in `config/config.ini-php` with the new URL.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
