### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -40,7 +40,7 @@ ynh_config_add --template="cron" --destination="/etc/cron.d/$app"
 ynh_script_progression "Finalizing installation..."
 ynh_local_curl "/index.php?action=databaseSetup" "host=127.0.0.1" "username=$db_user" "password=$db_pwd" "dbname=$db_name" "tables_prefix=matomo_" "adapter=PDO\\MYSQL"
 ynh_local_curl "/index.php?action=setupSuperUser&module=Installation" "login=$admin" "password=$password" "password_bis=$password" "email=$(ynh_user_get_info --username=$admin --key=mail)" "subscribe_newsletter_piwikorg=0" "subscribe_newsletter_professionalservices=0"
-ynh_local_curl "/index.php?action=firstWebsiteSetup&module=Installation" "siteName=$domain" "url=https://$domain$path" "timezone=$(cat /etc/timezone)" "ecommerce=0"
+ynh_local_curl "/index.php?action=firstWebsiteSetup&module=Installation" "siteName=$domain" "url=https://$domain$path" "timezone=$(timedatectl show --value --property=Timezone)" "ecommerce=0"
 ynh_local_curl "/index.php?action=finished&clientProtocol=https&module=Installation" "do_not_track=1" "anonymise_ip=1"
 
 #=================================================


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.